### PR TITLE
Update OWLAPI version in dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<owlapi.version>3.4.5</owlapi.version>
+		<owlapi.version>4.0.2</owlapi.version>
 		<!--protege.version>5.0.0-beta-05-SNAPSHOT</protege.version -->
 		<protege.version>4.3.0</protege.version>
 		<java.required.version>1.6</java.required.version>


### PR DESCRIPTION
elk-owlapi 0.4.* should work with OWLAPI 4 (which it does), however because of this dependency version it will currently pull and run OWLAPI 3.4 and cause trouble.

Here is a workaround if you are using Grapes in Groovy:

```groovy
@Grab(group='org.semanticweb.elk', module='elk-owlapi', version='0.4.2'),
@Grab(group='net.sourceforge.owlapi', module='owlapi-api', version='4.0.2'),
@Grab(group='net.sourceforge.owlapi', module='owlapi-apibinding', version='4.0.2'),
@Grab(group='net.sourceforge.owlapi', module='owlapi-impl', version='4.0.2'),
```